### PR TITLE
Bump AWS SDK and fix static linking with newer SDK.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,19 +9,23 @@ jobs:
       - run:
           command: sudo apt-get update && sudo apt-get install build-essential gcc g++ cmake libcurl4-openssl-dev libssl-dev libopencryptoki-dev libjson-c-dev
       - restore_cache:
-          key: aws-sdk-cpp-1.8.186
+          key: aws-sdk-cpp-1.9.150
       - run:
           command: |
             if [[ ! -e ~/aws-sdk-cpp ]]; then
-                curl -o ~/aws-sdk-cpp.tar.gz -L https://github.com/aws/aws-sdk-cpp/archive/1.8.186.tar.gz
-                [[ "dJMiqL5FlEclEt+KIdkzjXGBxkOgDgig/xLwfoMeM0Y=" == $(openssl dgst -sha256 -binary < ~/aws-sdk-cpp.tar.gz  | openssl enc -base64) ]] || exit 1
+                curl -o ~/aws-sdk-cpp.tar.gz -L https://github.com/aws/aws-sdk-cpp/archive/1.9.150.tar.gz
+                [[ "918nLtmn9yKGG11TcsGi0ws5ry8Jhw5H18AZkNXqMJU=" == $(openssl dgst -sha256 -binary < ~/aws-sdk-cpp.tar.gz  | openssl enc -base64) ]] || exit 1
                 mkdir ~/aws-sdk-cpp-src
                 tar -C ~/aws-sdk-cpp-src --strip-components=1 -zxf ~/aws-sdk-cpp.tar.gz
+                # Bugfix for https://github.com/aws/aws-sdk-cpp/issues/1769
+                curl -o ~/aws-sdk-cpp-src/prefetch_crt_dependency.sh https://raw.githubusercontent.com/aws/aws-sdk-cpp/2f4f7647e5ca6bf1c04a3ed7d14bebb8ad37f687/prefetch_crt_dependency.sh
+                [[ "GiRnJvH2KKlkbIX+jbdkAvv5sWADE+oBnad0rNPeqPw=" == $(openssl dgst -sha256 -binary < ~/aws-sdk-cpp-src/prefetch_crt_dependency.sh | openssl enc -base64) ]] || exit 1
+                cd ~/aws-sdk-cpp-src && ./prefetch_crt_dependency.sh
                 mkdir ~/aws-sdk-cpp-src/sdk_build
                 cd ~/aws-sdk-cpp-src/sdk_build && cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_ONLY=kms -DENABLE_TESTING=OFF -DCMAKE_INSTALL_PREFIX=$HOME/aws-sdk-cpp -DBUILD_SHARED_LIBS=OFF && make && make install
             fi
       - save_cache:
-          key: aws-sdk-cpp-1.8.186
+          key: aws-sdk-cpp-1.9.150
           paths:
             - ~/aws-sdk-cpp
       - run:


### PR DESCRIPTION
Credit to @ozbenh for the Makefile patch to fix the static linking for newer AWS SDK versions.