### PR TITLE
build fixes and support for GPG signing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,23 +7,20 @@ commands:
       - run:
           command: sudo apt-get update && sudo apt-get install build-essential gcc g++ cmake libcurl4-openssl-dev libssl-dev libopencryptoki-dev libjson-c-dev libp11-kit-dev
       - restore_cache:
-          key: aws-sdk-cpp-1.9.150-{{arch}}
+          key: aws-sdk-cpp-1.9.332-{{arch}}
       - run:
           command: |
             if [[ ! -e ~/aws-sdk-cpp ]]; then
-                curl -o ~/aws-sdk-cpp.tar.gz -L https://github.com/aws/aws-sdk-cpp/archive/1.9.150.tar.gz
-                [[ "918nLtmn9yKGG11TcsGi0ws5ry8Jhw5H18AZkNXqMJU=" == $(openssl dgst -sha256 -binary < ~/aws-sdk-cpp.tar.gz  | openssl enc -base64) ]] || exit 1
+                curl -o ~/aws-sdk-cpp.tar.gz -L https://github.com/aws/aws-sdk-cpp/archive/1.9.332.tar.gz
+                [[ "rvXfGzXiqN09KrHlc/kjuTlFifAnt66u2uvDDPQf/NM=" == $(openssl dgst -sha256 -binary < ~/aws-sdk-cpp.tar.gz  | openssl enc -base64) ]] || exit 1
                 mkdir ~/aws-sdk-cpp-src
                 tar -C ~/aws-sdk-cpp-src --strip-components=1 -zxf ~/aws-sdk-cpp.tar.gz
-                # Bugfix for https://github.com/aws/aws-sdk-cpp/issues/1769
-                curl -o ~/aws-sdk-cpp-src/prefetch_crt_dependency.sh https://raw.githubusercontent.com/aws/aws-sdk-cpp/2f4f7647e5ca6bf1c04a3ed7d14bebb8ad37f687/prefetch_crt_dependency.sh
-                [[ "GiRnJvH2KKlkbIX+jbdkAvv5sWADE+oBnad0rNPeqPw=" == $(openssl dgst -sha256 -binary < ~/aws-sdk-cpp-src/prefetch_crt_dependency.sh | openssl enc -base64) ]] || exit 1
                 cd ~/aws-sdk-cpp-src && ./prefetch_crt_dependency.sh
                 mkdir ~/aws-sdk-cpp-src/sdk_build
                 cd ~/aws-sdk-cpp-src/sdk_build && cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_ONLY=kms -DENABLE_TESTING=OFF -DCMAKE_INSTALL_PREFIX=$HOME/aws-sdk-cpp -DBUILD_SHARED_LIBS=OFF && make && make install
             fi
       - save_cache:
-          key: aws-sdk-cpp-1.9.150-{{arch}}
+          key: aws-sdk-cpp-1.9.332-{{arch}}
           paths:
             - ~/aws-sdk-cpp
       - run:

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ ifeq ($(AWS_SDK_C_STATIC),y)
   STATIC_LIBS += $(AWS_SDK_LIB_PATH)/libaws-c-cal.a
   STATIC_LIBS += $(AWS_SDK_LIB_PATH)/libaws-c-compression.a
   STATIC_LIBS += $(AWS_SDK_LIB_PATH)/libaws-c-s3.a
+  STATIC_LIBS += $(AWS_SDK_LIB_PATH)/libaws-c-sdkutils.a
   STATIC_LIBS += $(AWS_SDK_LIB_PATH)/libs2n.a
   STATIC_LIBS += -Wl,--end-group
 else ifeq ($(AWS_SDK_C_STATIC),n)

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ p11tool --list-token-urls
 
 An example for kernel module signing [can be found here](kernel_signing.md).
 
+## GPG Signing
+
+An example for GPG signing [can be found here](gpg_signing.md).
+
 ## pesign
 
 pesign is used by most Linux distributions to sign PE binaries for secure boot

--- a/aws_kms_pkcs11.cpp
+++ b/aws_kms_pkcs11.cpp
@@ -301,6 +301,10 @@ CK_RV C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo) {
     memcpy(pInfo->label, label.c_str(), label_len);
     memset(pInfo->manufacturerID, ' ', 32);
     memcpy(pInfo->manufacturerID, "aws_kms", 7);
+    memset(pInfo->model, ' ', 16);
+    memcpy(pInfo->model, "0", 1);
+    memset(pInfo->serialNumber, ' ', 16);
+    memcpy(pInfo->serialNumber, "0", 1);
     return CKR_OK;
 }
 


### PR DESCRIPTION
As a bit of background, I've been working on using the `pesign` support added in #11 to implement Secure Boot for Bottlerocket. The first commit fixes a minor issue with missing symbols that I ran into when trying to get that going on a newer version of the SDK. It doesn't appear that the bugfix for `prefetch_crt_dependency.sh` is required any more, so I dropped that also.

I ended up wanting to sign the GRUB config as well, and GRUB only supports GPG-style detached signatures. I found `gnupg-pkcs11-scd` and figured I'd try it with `aws-kms-pkcs11`. It mostly worked out of the box, except that the `pkcs11-helper` function for [serializing tokens](https://github.com/OpenSC/pkcs11-helper/blob/9fa150329535e1cccb5a3451b2249365571b66d7/lib/pkcs11h-serialization.c#L64) doesn't handle a missing "model" field correctly, resulting in an error when [deserializing tokens](https://github.com/OpenSC/pkcs11-helper/blob/9fa150329535e1cccb5a3451b2249365571b66d7/lib/pkcs11h-serialization.c#L153). It looks like a missing "serial" field would cause a similar problem.

I don't know what good values for these fields are but I figured "0" might be harmless. The second commit has that change. Arguably this is something that `pkcs11-helper` should handle more gracefully, but I saw 205b0ba1f19281bf257b71a5273bab48b13df46b and thought you might be OK with a patch.

For actually making `gpg` work, I followed [this guide](https://sztsian.github.io/2022/02/20/Using-PKCS11-Token-With-GPG.html). There were just enough differences that I figured documentation here would be useful, especially if someone wanted to automate the steps. The commands were involved enough that I thought a separate guide made sense, like the one for kernel module signing.

I'm happy to rework any of this, split it up into different PRs, or drop anything that's objectionable. 

