### PR TITLE
Misc fixes/improvements and ability to retrieve certs from acm-pca

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
                 tar -C ~/aws-sdk-cpp-src --strip-components=1 -zxf ~/aws-sdk-cpp.tar.gz
                 cd ~/aws-sdk-cpp-src && ./prefetch_crt_dependency.sh
                 mkdir ~/aws-sdk-cpp-src/sdk_build
-                cd ~/aws-sdk-cpp-src/sdk_build && cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_ONLY=kms -DENABLE_TESTING=OFF -DCMAKE_INSTALL_PREFIX=$HOME/aws-sdk-cpp -DBUILD_SHARED_LIBS=OFF && make && make install
+                cd ~/aws-sdk-cpp-src/sdk_build && cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_ONLY="kms;acm-pca" -DENABLE_TESTING=OFF -DCMAKE_INSTALL_PREFIX=$HOME/aws-sdk-cpp -DBUILD_SHARED_LIBS=OFF && make && make install
             fi
       - save_cache:
           key: aws-sdk-cpp-1.9.332-{{arch}}

--- a/Makefile
+++ b/Makefile
@@ -114,12 +114,14 @@ LIBS :=
 ifeq ($(AWS_SDK_CPP_STATIC),y)
   $(info Using C++ SDK static libraries)
   STATIC_LIBS += $(AWS_SDK_LIB_PATH)/libaws-cpp-sdk-kms.a
+  STATIC_LIBS += $(AWS_SDK_LIB_PATH)/libaws-cpp-sdk-acm-pca.a
   STATIC_LIBS += $(AWS_SDK_LIB_PATH)/libaws-cpp-sdk-core.a
   STATIC_LIBS += $(AWS_SDK_LIB_PATH)/libaws-crt-cpp.a
 else ifeq ($(AWS_SDK_CPP_STATIC),n)
   $(info Using C++ SDK dynamic libraries)
   LIBS += $(AWS_SDK_LIB_PATH)/libaws-cpp-sdk-core.so
   LIBS += $(AWS_SDK_LIB_PATH)/libaws-cpp-sdk-kms.so
+  LIBS += $(AWS_SDK_LIB_PATH)/libaws-cpp-sdk-acm-pca.so
 else
     $(error Unrecognized value for AWS_SDK_CPP_STATIC, use y or n)
 endif

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ The `slots` key is the only supported top-level attribute at the moment. This is
 | aws\_region | N | us-west-2 | The AWS region where the above key resides. Uses the AWS default if not specified. |
 | certificate | N | MIIBMjCB2... | A base64-encoded DER-encoded X.509 certificate to make available as an object on this slot. This is useful for use-cases where a signing library expects both a certificate and key available on the PKCS#11 token. You can generate a certificate with this format with a command such as `openssl x509 -in mycert.pem -outform der \| openssl base64 -A` |
 | certificate\_path | N | /etc/aws-kms-pkcs11/mycert.pem | Same as "certificate" but refers to a PEM certificate on disk instead of embedding the certificate value into the config. |
+| certificate_arn | N |  arn:aws:acm-pca:us-west-2:123456789876:certificate-authority/xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx/certificate/xxxxxxxxxxxxxxxxxxxx | Same as "certificate" but refers to a PEM certificate in ACM-PCA. |
+| ca_arn | N |  arn:aws:acm-pca:us-west-2:123456789876:certificate-authority/xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx | Optionally provide the ARN of the CA authority that owns the certificate specified in "certificate_arn". If unspecified, extracted from certificate_arn |
 
 If you are encountering errors using this provider, try setting the `AWS_KMS_PKCS11_DEBUG` environment variable to a non-empty value. This should enable debug logging to stdout from the module.
 

--- a/attributes.cpp
+++ b/attributes.cpp
@@ -216,7 +216,7 @@ CK_RV getKmsKeyAttributeValue(AwsKmsSlot& slot, CK_ATTRIBUTE_TYPE attr, CK_VOID_
     return CKR_OK;
 }
 
-CK_RV do_get_raw_cert(X509* cert, CK_VOID_PTR pValue, CK_ULONG_PTR pulValueLen) {
+CK_RV do_get_raw_cert(const X509* cert, CK_VOID_PTR pValue, CK_ULONG_PTR pulValueLen) {
     CK_BYTE_PTR buffer = NULL;
     CK_ULONG len = i2d_X509(cert, &buffer);
     CK_RV ret = CKR_FUNCTION_FAILED;
@@ -226,7 +226,7 @@ CK_RV do_get_raw_cert(X509* cert, CK_VOID_PTR pValue, CK_ULONG_PTR pulValueLen) 
     return ret;    
 }
 
-CK_RV do_get_raw_name(X509_NAME* name, CK_VOID_PTR pValue, CK_ULONG_PTR pulValueLen) {
+CK_RV do_get_raw_name(const X509_NAME* name, CK_VOID_PTR pValue, CK_ULONG_PTR pulValueLen) {
     CK_BYTE_PTR buffer = NULL;
     CK_ULONG len = i2d_X509_NAME(name, &buffer);
     CK_RV ret = CKR_FUNCTION_FAILED;
@@ -236,7 +236,7 @@ CK_RV do_get_raw_name(X509_NAME* name, CK_VOID_PTR pValue, CK_ULONG_PTR pulValue
     return ret;    
 }
 
-CK_RV do_get_raw_integer(ASN1_INTEGER* serial, CK_VOID_PTR pValue, CK_ULONG_PTR pulValueLen) {
+CK_RV do_get_raw_integer(const ASN1_INTEGER* serial, CK_VOID_PTR pValue, CK_ULONG_PTR pulValueLen) {
     CK_BYTE_PTR buffer = NULL;
     CK_ULONG len = i2d_ASN1_INTEGER(serial, &buffer);
     CK_RV ret = CKR_FUNCTION_FAILED;
@@ -247,7 +247,7 @@ CK_RV do_get_raw_integer(ASN1_INTEGER* serial, CK_VOID_PTR pValue, CK_ULONG_PTR 
 }
 
 CK_RV getCertificateAttributeValue(AwsKmsSlot& slot, CK_ATTRIBUTE_TYPE attr, CK_VOID_PTR pValue, CK_ULONG_PTR pulValueLen) {
-    X509* cert = slot.GetCertificate();
+    const X509* cert = slot.GetCertificate();
     if (cert == NULL) {
         return CKR_OBJECT_HANDLE_INVALID;
     }
@@ -279,7 +279,7 @@ CK_RV getCertificateAttributeValue(AwsKmsSlot& slot, CK_ATTRIBUTE_TYPE attr, CK_
             return do_get_raw_name(X509_get_issuer_name(cert), pValue, pulValueLen);
 
         case CKA_SERIAL_NUMBER:
-            return do_get_raw_integer(X509_get_serialNumber(cert), pValue, pulValueLen);
+            return do_get_raw_integer(X509_get0_serialNumber(cert), pValue, pulValueLen);
 
         case CKA_VALUE:
             return do_get_raw_cert(cert, pValue, pulValueLen);

--- a/attributes.cpp
+++ b/attributes.cpp
@@ -63,7 +63,7 @@ CK_RV getCommonAttributeValue(AwsKmsSlot& slot, CK_ATTRIBUTE_TYPE attr, CK_VOID_
         case CKA_LABEL: {
             string label = slot.GetLabel();
             if (label.length() == 0) {
-                    label = slot.GetKmsKeyId();
+                label = slot.GetKmsKeyId();
             }
             return copyAttribute(pValue, pulValueLen, label.c_str(), label.length());
         }

--- a/aws_kms_pkcs11.cpp
+++ b/aws_kms_pkcs11.cpp
@@ -229,10 +229,10 @@ CK_RV C_Initialize(CK_VOID_PTR pInitArgs) {
         debug("No slots were configured and no KMS keys could be listed via an API call.");
         result = CKR_FUNCTION_FAILED;
     } else {
-	debug("Configured slots:");
-	for (size_t i = 0; i < slots->size(); i++) {
-	    debug("  %s", slots->at(i).GetKmsKeyId().c_str());
-	}
+        debug("Configured slots:");
+        for (size_t i = 0; i < slots->size(); i++) {
+            debug("  %s", slots->at(i).GetKmsKeyId().c_str());
+        }
     }
 
     if (result != CKR_OK) {

--- a/aws_kms_pkcs11.cpp
+++ b/aws_kms_pkcs11.cpp
@@ -241,7 +241,7 @@ CK_RV C_Finalize(CK_VOID_PTR pReserved) {
     if (slots != NULL) {
         for (size_t i = 0; i < slots->size(); i++) {
             AwsKmsSlot& slot = slots->at(i);
-            X509* cert = slot.GetCertificate();
+            X509* cert = const_cast <X509 *>(slot.GetCertificate());
             if (cert != NULL) {
                 X509_free(cert);
             }

--- a/aws_kms_pkcs11.cpp
+++ b/aws_kms_pkcs11.cpp
@@ -92,6 +92,7 @@ static CK_RV load_config(json_object** config) {
 
         struct json_tokener* tok = json_tokener_new();
         struct json_object* conf = json_tokener_parse_ex(tok, buffer, file_size);
+        enum json_tokener_error errval = json_tokener_get_error(tok);
         json_tokener_free(tok);
         free(buffer);
 
@@ -99,10 +100,9 @@ static CK_RV load_config(json_object** config) {
             *config = conf;
             return CKR_OK;
         } else {
-            debug("Failed to parse config: %s", path.c_str());
+            debug("Failed to parse config %s: %s", path.c_str(), json_tokener_error_desc(errval));
         }
     }
-
     *config = json_object_new_object();
     return CKR_OK;
 }

--- a/aws_kms_pkcs11.cpp
+++ b/aws_kms_pkcs11.cpp
@@ -129,17 +129,23 @@ CK_RV C_Initialize(CK_VOID_PTR pInitArgs) {
         return res;
     }
 
+    string glob_aws_region;
+    struct json_object* val;
+
+    if (json_object_object_get_ex(config, "aws_region", &val) && json_object_is_type(val, json_type_string)) {
+        glob_aws_region = string(json_object_get_string(val));
+    }
+
     active_sessions = new vector<CkSession*>();
     slots = new vector<AwsKmsSlot>();
     struct json_object* slots_array;
     if (json_object_object_get_ex(config, "slots", &slots_array) && json_object_is_type(slots_array, json_type_array)) {
-	    for (size_t i = 0; i < (size_t)json_object_array_length(slots_array); i++) {
+            for (size_t i = 0; i < (size_t)json_object_array_length(slots_array); i++) {
             struct json_object* slot_item = json_object_array_get_idx(slots_array, i);
             if (json_object_is_type(slot_item, json_type_object)) {
-                struct json_object* val;
                 string label;
                 string kms_key_id;
-                string aws_region;
+                string aws_region = glob_aws_region;
                 X509* certificate = NULL;
                 if (json_object_object_get_ex(slot_item, "label", &val) && json_object_is_type(val, json_type_string)) {
                     label = string(json_object_get_string(val));

--- a/aws_kms_slot.cpp
+++ b/aws_kms_slot.cpp
@@ -9,23 +9,24 @@
 
 using std::string;
 
-AwsKmsSlot::AwsKmsSlot(string label, string kms_key_id, string aws_region, X509* certificate) {
-    this->label = label;
-    this->kms_key_id = kms_key_id;
-    this->aws_region = aws_region;
-    this->public_key_data_fetched = false;
-    this->certificate = certificate;
+AwsKmsSlot::AwsKmsSlot(const string &label, const string &kms_key_id, const string aws_region,
+		       const X509* certificate) :
+	label(label), kms_key_id(kms_key_id), aws_region(aws_region),
+	certificate(certificate),
+	public_key_data_fetched(false)
+{
 }
-string AwsKmsSlot::GetLabel() {
+
+const string &AwsKmsSlot::GetLabel() {
     return this->label;
 }
-string AwsKmsSlot::GetAwsRegion() {
+const string & AwsKmsSlot::GetAwsRegion() {
     return this->aws_region;
 }
-string AwsKmsSlot::GetKmsKeyId() {
+const string & AwsKmsSlot::GetKmsKeyId() {
     return this->kms_key_id;
 }
-X509* AwsKmsSlot::GetCertificate() {
+const X509* AwsKmsSlot::GetCertificate() {
     return this->certificate;
 }
 void AwsKmsSlot::FetchPublicKeyData() {
@@ -33,7 +34,7 @@ void AwsKmsSlot::FetchPublicKeyData() {
         return;
     }
     Aws::Client::ClientConfiguration awsConfig;
-    if (this->aws_region.length() > 0) {
+    if (!this->aws_region.empty()) {
         awsConfig.region = this->aws_region;
     }
     Aws::KMS::KMSClient kms(awsConfig);

--- a/aws_kms_slot.h
+++ b/aws_kms_slot.h
@@ -9,20 +9,22 @@ using std::string;
 
 class AwsKmsSlot {
 private:
-    string label;
-    string aws_region;
-    string kms_key_id;
+    const string label;
+    const string kms_key_id;
+    const string aws_region;
+    const X509* certificate;
     bool public_key_data_fetched;
+
     Aws::Utils::ByteBuffer public_key_data;
     Aws::KMS::Model::KeySpec key_spec;
-    X509* certificate;
     void FetchPublicKeyData();
 public:
-    AwsKmsSlot(string label, string kms_key_id, string aws_region, X509* certificate);
-    string GetLabel();
-    string GetKmsKeyId();
-    string GetAwsRegion();
-    X509* GetCertificate();
+    AwsKmsSlot(const string &label, const string &kms_key_id, const string aws_region,
+	       const X509* certificate);
+    const string& GetLabel();
+    const string& GetKmsKeyId();
+    const string& GetAwsRegion();
+    const X509* GetCertificate();
     Aws::Utils::ByteBuffer GetPublicKeyData();
     Aws::KMS::Model::KeySpec GetKeySpec();
 };

--- a/certificates.cpp
+++ b/certificates.cpp
@@ -3,6 +3,15 @@
 #include <openssl/pem.h>
 #include <openssl/x509.h>
 
+#include <aws/core/Aws.h>
+#include <aws/acm-pca/ACMPCAClient.h>
+#include <aws/acm-pca/model/GetCertificateRequest.h>
+#include <aws/acm-pca/model/GetCertificateResult.h>
+
+#include "debug.h"
+
+using std::string;
+
 X509* parseCertificateFromFile(const char* filename) {
     int res;
     long len;
@@ -47,5 +56,31 @@ X509* parseCertificateFromB64Der(const char* b64Der) {
     BIO_push(b64, bio_mem);
     X509* cert = d2i_X509_bio(b64, NULL);
     BIO_free_all(b64);
+    return cert;
+}
+
+X509* parseCertificateFromARN(const string &ca_arn, const string &arn, const std::string &region) {
+    Aws::Client::ClientConfiguration awsConfig;
+
+    if (!region.empty())
+	    awsConfig.region = region;
+    Aws::ACMPCA::ACMPCAClient acmpca(awsConfig);
+    Aws::ACMPCA::Model::GetCertificateRequest req;
+
+    req.SetCertificateArn(arn);
+    req.SetCertificateAuthorityArn(ca_arn);
+    auto res = acmpca.GetCertificate(req);
+    if (!res.IsSuccess()) {
+	debug("Failed to retreive certificate %s from CA %s\n", arn, ca_arn);
+	return NULL;
+    }
+    auto pem = res.GetResult().GetCertificate();
+    auto bio = BIO_new_mem_buf((char *)pem.c_str(), -1);
+    if (!bio) {
+	    debug("Failed to allocate BIO for cert\n");
+	    return NULL;
+    }
+    auto cert = PEM_read_bio_X509(bio, NULL, 0, NULL);
+    BIO_free(bio);
     return cert;
 }

--- a/certificates.h
+++ b/certificates.h
@@ -2,3 +2,4 @@
 
 X509* parseCertificateFromFile(const char* filename);
 X509* parseCertificateFromB64Der(const char* b64Der);
+X509* parseCertificateFromARN(const string &ca_arn, const string &arn, const std::string &region);


### PR DESCRIPTION
This improves the config file parsing a bit, fixes a crashing bug when hitting the "no config file" fallback, and adds the ability to retrieve certificates directly from acm-pca by ARN