### PR TITLE
Fix build with earlier openssl versions and build on Amazon Linux 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ endif
 
 # Try to find which subdir of the SDK has the libraries
 ifneq ($(AWS_SDK_PATH),)
-  ifneq ($(wildcard $(AWS_SDK_PATH)/lib),)
+  ifneq ($(wildcard $(AWS_SDK_PATH)/lib/libaws-c-common.*),)
     AWS_SDK_LIB_PATH := $(addsuffix /lib,$(AWS_SDK_PATH))
-  else ifneq ($(wildcard $(AWS_SDK_PATH)/lib64),)
+  else ifneq ($(wildcard $(AWS_SDK_PATH)/lib64/libaws-c-common.*),)
     AWS_SDK_LIB_PATH := $(addsuffix /lib64,$(AWS_SDK_PATH))
   else
     $(error neither lib or lib64 found in AWS SDK)

--- a/aws_kms_pkcs11.cpp
+++ b/aws_kms_pkcs11.cpp
@@ -14,6 +14,7 @@
 #include <aws/kms/model/SignRequest.h>
 
 #include "pkcs11_compat.h"
+#include "openssl_compat.h"
 #include "attributes.h"
 #include "aws_kms_slot.h"
 #include "certificates.h"

--- a/certificates.cpp
+++ b/certificates.cpp
@@ -9,6 +9,7 @@
 #include <aws/acm-pca/model/GetCertificateResult.h>
 
 #include "debug.h"
+#include "openssl_compat.h"
 
 using std::string;
 

--- a/openssl_compat.h
+++ b/openssl_compat.h
@@ -1,0 +1,22 @@
+#ifndef __OPENSSL_COMPAT_H
+#define __OPENSSL_COMPAT_H
+
+#include <openssl/opensslv.h>
+
+#if OPENSSL_VERSION_NUMBER < 0x10101000L
+#define EVP_PKEY_get0_RSA(_pkey) ((_pkey)->pkey.rsa)
+#define RSA_get0_n(_rsa) ((_rsa)->n)
+#define RSA_get0_e(_rsa) ((_rsa)->e)
+#define EVP_PKEY_get0_EC_KEY(_pkey) ((_pkey)->pkey.ec)
+#define ECDSA_SIG_get0_r(_sig) ((_sig)->r)
+#define ECDSA_SIG_get0_s(_sig) ((_sig)->s)
+#define X509_get0_serialNumber X509_get_serialNumber
+#endif
+
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+#define OSSL_UNCONST(_type, _expr) (const_cast <_type *>(_expr))
+#else
+#define OSSL_UNCONST(_type, _expr) (_expr)
+#endif
+
+#endif /* __OPENSSL_COMPAT_H */


### PR DESCRIPTION
My recent changes broke the build on OpenSSL < 3.0. I was carrying a fix for OpenSSL 1.0.2 for a while (for Amazon Linux), this extends that fix to also deal with 1.1 and adds a Makefile change that improves the auto-detection of the SDK location, enabling the plugin to build out of the box on AL2.