### PR TITLE
Fix build on some modern Ubuntu systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 # Try to locate the AWS SDK if not specified with AWS_SDK_PATH
+MACHINE := $(shell gcc -dumpmachine)
 ifeq ($(AWS_SDK_PATH),)
   ifneq ($(wildcard /usr/include/aws),)
     AWS_SDK_PATH := /usr
@@ -10,11 +11,13 @@ ifeq ($(AWS_SDK_PATH),)
 endif
 
 # Try to find which subdir of the SDK has the libraries
-ifneq ($(AWS_SDK_PATH),)
+ifneq ($(AWS_SDK_LIB_PATH),)
   ifneq ($(wildcard $(AWS_SDK_PATH)/lib/libaws-c-common.*),)
     AWS_SDK_LIB_PATH := $(addsuffix /lib,$(AWS_SDK_PATH))
   else ifneq ($(wildcard $(AWS_SDK_PATH)/lib64/libaws-c-common.*),)
     AWS_SDK_LIB_PATH := $(addsuffix /lib64,$(AWS_SDK_PATH))
+  else ifneq ($(wildcard $(AWS_SDK_PATH)/lib/$(MACHINE)/libaws-c-common.*),)
+    AWS_SDK_LIB_PATH := $(addsuffix /lib/$(MACHINE),$(AWS_SDK_PATH))
   else
     $(error neither lib or lib64 found in AWS SDK)
   endif


### PR DESCRIPTION
Modern Ubuntu systems place shared libraries in a subdirectory of `/usr/lib` indicated by the output of `gcc -dumpmachine`; on modern x86_64 systems this is `/usr/lib/x86_64-linux-gnu`. The Makefile did not account for this case, therefore requiring modifications before building on Ubuntu systems.

This commit also modifies the Makefile to respect an `AWS_SDK_LIB_PATH` that was overridden on the command line.