### PR TITLE
Add compile-time support for `allowSystemProxy` client config setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,16 @@ ifeq ($(JSON_C_INC),)
   endif
 endif
 
+ifdef AWS_SDK_USE_SYSTEM_PROXY
+  ifeq ($(AWS_SDK_USE_SYSTEM_PROXY),y)
+    PROXY_CFLAGS := -DAWS_SDK_USE_SYSTEM_PROXY=1
+  else ifeq ($(AWS_SDK_USE_SYSTEM_PROXY),n)
+    PROXY_CFLAGS :=
+  else
+    $(error Invalid value for AWS_SDK_USE_SYSTEM_PROXY, use y or n)
+  endif
+endif
+
 # Build library link list
 STATIC_LIBS :=
 LIBS :=
@@ -166,15 +176,15 @@ test: aws_kms_pkcs11_test certificates_test
 	AWS_KMS_PKCS11_DEBUG=1 ./aws_kms_pkcs11_test
 
 certificates_test: certificates.cpp certificates_test.cpp
-	g++ -g -fPIC -Wall -I$(AWS_SDK_PATH)/include $(PKCS11_INC) $(JSON_C_INC) -fno-exceptions -std=c++17 \
+	g++ -g -fPIC -Wall -I$(AWS_SDK_PATH)/include $(PKCS11_INC) $(JSON_C_INC) $(PROXY_CFLAGS) -fno-exceptions -std=c++17 \
         debug.cpp certificates.cpp certificates_test.cpp -o certificates_test $(STATIC_LIBS) $(LIBS) -lcrypto -ljson-c -lcurl
 
 aws_kms_pkcs11_test: aws_kms_pkcs11_test.c aws_kms_pkcs11.so
-	g++ -g -fPIC -Wall -I$(AWS_SDK_PATH)/include $(PKCS11_INC) $(JSON_C_INC) -fno-exceptions -std=c++17 \
+	g++ -g -fPIC -Wall -I$(AWS_SDK_PATH)/include $(PKCS11_INC) $(JSON_C_INC) $(PROXY_CFLAGS) -fno-exceptions -std=c++17 \
         aws_kms_pkcs11_test.c -o aws_kms_pkcs11_test -ldl
 
 aws_kms_pkcs11.so: aws_kms_pkcs11.cpp unsupported.cpp aws_kms_slot.cpp debug.cpp attributes.cpp certificates.cpp
-	g++ -shared -fPIC -Wall -I$(AWS_SDK_PATH)/include $(PKCS11_INC) $(JSON_C_INC) -fno-exceptions -std=c++17 $(SRC) \
+	g++ -shared -fPIC -Wall -I$(AWS_SDK_PATH)/include $(PKCS11_INC) $(JSON_C_INC) $(PROXY_CFLAGS) -fno-exceptions -std=c++17 $(SRC) \
 	    -o aws_kms_pkcs11.so $(STATIC_LIBS) $(LIBS) -lcrypto -ljson-c -lcurl
 
 install: aws_kms_pkcs11.so

--- a/README.md
+++ b/README.md
@@ -220,4 +220,6 @@ the static ones if available, otherwise the dynamic ones:
 `AWS_SDK_CPP_STATIC = y` : Force use of static libraries for C++  
 `AWS_SDK_CPP_STATIC = n` : Force use of dynamic libraries for C++  
 
-Finally the variable `PKCS11_MOD_PATH` can be used to control the destination directory for `make install`
+The variable `PKCS11_MOD_PATH` can be used to control the destination directory for `make install`.
+
+The variable `AWS_SDK_USE_SYSTEM_PROXY` can be set to `y` to cause aws-kms-pkcs11 to use the HTTP proxy server set in the `HTTPS_PROXY` environment variable. This defaults to `n`, meaning the proxy settings from the environment are ignored by default. See [AWS Command Line Interface - Use an HTTP proxy](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-proxy.html) and [aws-sdk-cpp#2679](https://github.com/aws/aws-sdk-cpp/pull/2679) for further details. Note that this option was, as of this writing, added relatively recently (September 2023) and the library may therefore not compile with `AWS_SDK_USE_SYSTEM_PROXY=y`.

--- a/aws_kms_pkcs11.cpp
+++ b/aws_kms_pkcs11.cpp
@@ -203,6 +203,9 @@ CK_RV C_Initialize(CK_VOID_PTR pInitArgs) {
     if (slots->size() == 0) {
         debug("No KMS key ids configured; listing all keys.");
         Aws::Client::ClientConfiguration awsConfig;
+#ifdef AWS_SDK_USE_SYSTEM_PROXY
+        awsConfig.allowSystemProxy = true;
+#endif
         Aws::KMS::KMSClient kms(awsConfig);
         Aws::KMS::Model::ListKeysRequest req;
         req.SetLimit(1000);
@@ -751,6 +754,9 @@ CK_RV C_Sign(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_ULONG ulDataLen, 
     }
 
     Aws::Client::ClientConfiguration awsConfig;
+#ifdef AWS_SDK_USE_SYSTEM_PROXY
+    awsConfig.allowSystemProxy = true;
+#endif
     if (slot.GetAwsRegion().length() > 0) {
         awsConfig.region = slot.GetAwsRegion();
     }

--- a/aws_kms_slot.cpp
+++ b/aws_kms_slot.cpp
@@ -34,6 +34,9 @@ void AwsKmsSlot::FetchPublicKeyData() {
         return;
     }
     Aws::Client::ClientConfiguration awsConfig;
+#ifdef AWS_SDK_USE_SYSTEM_PROXY
+    awsConfig.allowSystemProxy = true;
+#endif
     if (!this->aws_region.empty()) {
         awsConfig.region = this->aws_region;
     }

--- a/certificates.cpp
+++ b/certificates.cpp
@@ -62,6 +62,9 @@ X509* parseCertificateFromB64Der(const char* b64Der) {
 
 X509* parseCertificateFromARN(const string &ca_arn, const string &arn, const std::string &region) {
     Aws::Client::ClientConfiguration awsConfig;
+#ifdef AWS_SDK_USE_SYSTEM_PROXY
+    awsConfig.allowSystemProxy = true;
+#endif
 
     if (!region.empty())
 	    awsConfig.region = region;


### PR DESCRIPTION
At present, it's not possible to use aws-kms-pkcs11 with a proxy other than by manually editing source code and recompiling. This is obviously less-than-ideal.

The AWS C++ SDK recently added support for honoring traditional system proxy environment variables [1]. This commit starts using this new option in aws-kms-pkcs11.

The setting defaults to off, because the PR was only merged relatively recently (Sept 2023) and is not likely to have made it into distribution repositories yet. The setting can be toggled at compile time by setting `AWS_SDK_USE_SYSTEM_PROXY=y`, following the existing y/n conventions.

Documentation is updated accordingly.

[1] https://github.com/aws/aws-sdk-cpp/pull/2679