### PR TITLE
Various build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,8 @@ aws_kms_pkcs11.so: aws_kms_pkcs11.cpp unsupported.cpp aws_kms_slot.cpp debug.cpp
 	    -o aws_kms_pkcs11.so $(STATIC_LIBS) $(LIBS) -lcrypto -ljson-c -lcurl -lz
 
 install: aws_kms_pkcs11.so
-	cp aws_kms_pkcs11.so $(PKCS11_MOD_PATH)/
+	mkdir -p $(DESTDIR)$(PKCS11_MOD_PATH)
+	cp aws_kms_pkcs11.so $(DESTDIR)$(PKCS11_MOD_PATH)/
 
 uninstall:
-	rm -f $(PKCS11_MOD_PATH)/aws_kms_pkcs11.so
+	rm -f $(DESTDIR)$(PKCS11_MOD_PATH)/aws_kms_pkcs11.so

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ifeq ($(AWS_SDK_PATH),)
 endif
 
 # Try to find which subdir of the SDK has the libraries
-ifneq ($(AWS_SDK_PATH),)
+ifeq ($(AWS_SDK_LIB_PATH),)
   ifneq ($(wildcard $(AWS_SDK_PATH)/lib/libaws-c-common.*),)
     AWS_SDK_LIB_PATH := $(addsuffix /lib,$(AWS_SDK_PATH))
   else ifneq ($(wildcard $(AWS_SDK_PATH)/lib64/libaws-c-common.*),)

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ test: aws_kms_pkcs11_test certificates_test
 
 certificates_test: certificates.cpp certificates_test.cpp
 	g++ -g -fPIC -Wall -I$(AWS_SDK_PATH)/include $(PKCS11_INC) $(JSON_C_INC) $(PROXY_CFLAGS) -fno-exceptions -std=c++17 \
-        debug.cpp certificates.cpp certificates_test.cpp -o certificates_test $(STATIC_LIBS) $(LIBS) -lcrypto -ljson-c -lcurl
+        debug.cpp certificates.cpp certificates_test.cpp -o certificates_test $(STATIC_LIBS) $(LIBS) -lcrypto -ljson-c -lcurl -lz
 
 aws_kms_pkcs11_test: aws_kms_pkcs11_test.c aws_kms_pkcs11.so
 	g++ -g -fPIC -Wall -I$(AWS_SDK_PATH)/include $(PKCS11_INC) $(JSON_C_INC) $(PROXY_CFLAGS) -fno-exceptions -std=c++17 \
@@ -185,7 +185,7 @@ aws_kms_pkcs11_test: aws_kms_pkcs11_test.c aws_kms_pkcs11.so
 
 aws_kms_pkcs11.so: aws_kms_pkcs11.cpp unsupported.cpp aws_kms_slot.cpp debug.cpp util.cpp attributes.cpp certificates.cpp
 	g++ -shared -fPIC -Wall -I$(AWS_SDK_PATH)/include $(PKCS11_INC) $(JSON_C_INC) $(PROXY_CFLAGS) -fno-exceptions -std=c++17 $(SRC) \
-	    -o aws_kms_pkcs11.so $(STATIC_LIBS) $(LIBS) -lcrypto -ljson-c -lcurl
+	    -o aws_kms_pkcs11.so $(STATIC_LIBS) $(LIBS) -lcrypto -ljson-c -lcurl -lz
 
 install: aws_kms_pkcs11.so
 	cp aws_kms_pkcs11.so $(PKCS11_MOD_PATH)/

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ test: aws_kms_pkcs11_test certificates_test
 
 certificates_test: certificates.cpp certificates_test.cpp
 	g++ -g -fPIC -Wall -I$(AWS_SDK_PATH)/include $(PKCS11_INC) $(JSON_C_INC) $(PROXY_CFLAGS) -fno-exceptions -std=c++17 \
-        debug.cpp certificates.cpp certificates_test.cpp -o certificates_test $(STATIC_LIBS) $(LIBS) -lcrypto -ljson-c -lcurl -lz
+        debug.cpp util.cpp certificates.cpp certificates_test.cpp -o certificates_test $(STATIC_LIBS) $(LIBS) -lcrypto -ljson-c -lcurl -lz
 
 aws_kms_pkcs11_test: aws_kms_pkcs11_test.c aws_kms_pkcs11.so
 	g++ -g -fPIC -Wall -I$(AWS_SDK_PATH)/include $(PKCS11_INC) $(JSON_C_INC) $(PROXY_CFLAGS) -fno-exceptions -std=c++17 \

--- a/README.md
+++ b/README.md
@@ -248,6 +248,6 @@ the static ones if available, otherwise the dynamic ones:
 `AWS_SDK_CPP_STATIC = y` : Force use of static libraries for C++  
 `AWS_SDK_CPP_STATIC = n` : Force use of dynamic libraries for C++  
 
-The variable `PKCS11_MOD_PATH` can be used to control the destination directory for `make install`.
+The variable `PKCS11_MOD_PATH` can be used to control the destination directory for `make install`. The variable `DESTDIR` can be used to install to a staging directory.
 
 The variable `AWS_SDK_USE_SYSTEM_PROXY` can be set to `y` to cause aws-kms-pkcs11 to use the HTTP proxy server set in the `HTTPS_PROXY` environment variable. This defaults to `n`, meaning the proxy settings from the environment are ignored by default. See [AWS Command Line Interface - Use an HTTP proxy](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-proxy.html) and [aws-sdk-cpp#2679](https://github.com/aws/aws-sdk-cpp/pull/2679) for further details. Note that this option was, as of this writing, added relatively recently (September 2023) and the library may therefore not compile with `AWS_SDK_USE_SYSTEM_PROXY=y`.

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ The easiest way to install the provider is to download the binary artifact from 
 The Makefile in this repo tries to intuit the location of the various components and libraries it needs. This can be controlled by the following variables:
 
 `AWS_SDK_PATH`       : Path to the AWS sdk  
+`AWS_SDK_LIB_PATH`   : Path to the AWS sdk libraries (optional)
 `PKCS11_INC`         : Path to the pkcs11.h header file  
 `JSON_C_INC`         : Path to the json-c library headers  
 


### PR DESCRIPTION
While packaging aws-kms-pkcs11 for use on our infrastructure, I found a few issues with the build. I think these should be non-controversial, but let me know if you think otherwise.

For reference, https://github.com/dbnicholson/aws-kms-pkcs11/tree/endless/bookworm is the tree where I did the Debian packaging. The only patch I didn't include is [this one](https://github.com/dbnicholson/aws-kms-pkcs11/blob/endless/bookworm/debian/patches/no-kms-test.patch) that disables `aws_kms_pkcs11_test` during testing since there's no way to make it work automatically.