### PR TITLE
Add support to send debug output to stderr

### DIFF
--- a/aws_kms_pkcs11.cpp
+++ b/aws_kms_pkcs11.cpp
@@ -116,11 +116,13 @@ CK_RV C_Initialize(CK_VOID_PTR pInitArgs) {
 
     CK_RV result = CKR_OK;
 
-    debug_enabled = CK_FALSE;
+    debug_file = NULL;
     const char* debug_env_var = getenv("AWS_KMS_PKCS11_DEBUG");
     if (debug_env_var != NULL) {
-        if (strlen(debug_env_var) > 0) {
-            debug_enabled = CK_TRUE;
+        if (strcmp(debug_env_var, "stderr") == 0) {
+            debug_file = stderr;
+        } else if (strlen(debug_env_var) > 0) {
+            debug_file = stdout;
             debug("Debug enabled.");
         }
     }

--- a/debug.cpp
+++ b/debug.cpp
@@ -4,11 +4,11 @@
 #include <stdio.h>
 #include "debug.h"
 
-bool debug_enabled = false;
+FILE *debug_file = NULL;
 void debug(const char *fmt, ...) {
     va_list args;
 
-    if (!debug_enabled) {
+    if (debug_file == NULL) {
         return;
     }
 
@@ -19,7 +19,7 @@ void debug(const char *fmt, ...) {
     longer_fmt[strlen(fmt)+10] = '\0';
 
     va_start(args, fmt);
-    vprintf(longer_fmt, args);
+    vfprintf(debug_file, longer_fmt, args);
     va_end(args);
 
     free(longer_fmt);

--- a/debug.h
+++ b/debug.h
@@ -1,3 +1,4 @@
+#include <stdio.h>
 
-extern bool debug_enabled;
+extern FILE *debug_file;
 void debug(const char *fmt, ...);


### PR DESCRIPTION
Allow setting `AWS_KMS_PKCS11_DEBUG` to `stderr` to send the debug info to stderr, which is the only way to debug things when using behind p11-kit server as the latter uses stdout for the actual RPC protocol