### PR TITLE
Add ML-DSA signing support via CKM_ML_DSA

### DIFF
--- a/attributes.cpp
+++ b/attributes.cpp
@@ -69,6 +69,51 @@ CK_RV getCommonAttributeValue(AwsKmsSlot& slot, CK_ATTRIBUTE_TYPE attr, CK_VOID_
             return copyAttribute(pValue, pulValueLen, label.c_str(), label.length());
         }
 
+        case CKA_COPYABLE:
+            return copyBoolAttribute(pValue, pulValueLen, CK_FALSE);
+
+        case CKA_PUBLIC_KEY_INFO: {
+            // KMS GetPublicKey returns the SubjectPublicKeyInfo DER directly,
+            // which is exactly what CKA_PUBLIC_KEY_INFO is supposed to be.
+            Aws::Utils::ByteBuffer key_data = slot.GetPublicKeyData();
+            if (key_data.GetLength() == 0) {
+                return CKR_ATTRIBUTE_TYPE_INVALID;
+            }
+            return copyAttribute(pValue, pulValueLen,
+                                 key_data.GetUnderlyingData(), key_data.GetLength());
+        }
+
+        case CKA_PARAMETER_SET: {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+            // ML-DSA parameter set identifier per PKCS#11 v3.2.
+            // Inspect the SPKI to determine which variant.
+            Aws::Utils::ByteBuffer key_data = slot.GetPublicKeyData();
+            if (key_data.GetLength() == 0) {
+                return CKR_ATTRIBUTE_TYPE_INVALID;
+            }
+            const unsigned char* pubkey_bytes = key_data.GetUnderlyingData();
+            EVP_PKEY* pkey = d2i_PUBKEY(NULL, &pubkey_bytes, key_data.GetLength());
+            if (pkey == NULL) {
+                return CKR_FUNCTION_FAILED;
+            }
+            CK_ULONG param_set;
+            if (EVP_PKEY_is_a(pkey, "ML-DSA-44")) {
+                param_set = CKP_ML_DSA_44;
+            } else if (EVP_PKEY_is_a(pkey, "ML-DSA-65")) {
+                param_set = CKP_ML_DSA_65;
+            } else if (EVP_PKEY_is_a(pkey, "ML-DSA-87")) {
+                param_set = CKP_ML_DSA_87;
+            } else {
+                EVP_PKEY_free(pkey);
+                return CKR_ATTRIBUTE_TYPE_INVALID;
+            }
+            EVP_PKEY_free(pkey);
+            return copyAttribute(pValue, pulValueLen, &param_set, sizeof(CK_ULONG));
+#else
+            return CKR_ATTRIBUTE_TYPE_INVALID;
+#endif
+        }
+
         default:
             *pulValueLen = CK_UNAVAILABLE_INFORMATION;
             return CKR_ATTRIBUTE_TYPE_INVALID;
@@ -109,16 +154,20 @@ CK_RV getKmsKeyAttributeValue(AwsKmsSlot& slot, CK_ATTRIBUTE_TYPE attr, CK_VOID_
             }
 
             CK_OBJECT_CLASS key_type;
-            switch (EVP_PKEY_base_id(pkey)) {
-                case EVP_PKEY_RSA:
-                    key_type = CKK_RSA;
-                    break;
-                case EVP_PKEY_EC:
-                    key_type = CKK_ECDSA;
-                    break;
-                default:
-                    EVP_PKEY_free(pkey);
-                    return CKR_ATTRIBUTE_TYPE_INVALID;
+            int base_id = EVP_PKEY_base_id(pkey);
+            if (base_id == EVP_PKEY_RSA) {
+                key_type = CKK_RSA;
+            } else if (base_id == EVP_PKEY_EC) {
+                key_type = CKK_ECDSA;
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+            } else if (EVP_PKEY_is_a(pkey, "ML-DSA-44")
+                    || EVP_PKEY_is_a(pkey, "ML-DSA-65")
+                    || EVP_PKEY_is_a(pkey, "ML-DSA-87")) {
+                key_type = CKK_ML_DSA;
+#endif
+            } else {
+                EVP_PKEY_free(pkey);
+                return CKR_ATTRIBUTE_TYPE_INVALID;
             }
             EVP_PKEY_free(pkey);
             return copyAttribute(pValue, pulValueLen, &key_type, sizeof(CK_OBJECT_CLASS));

--- a/aws_kms_pkcs11.cpp
+++ b/aws_kms_pkcs11.cpp
@@ -9,9 +9,22 @@
 #include <vector>
 
 #include <aws/core/Aws.h>
+#include <aws/core/VersionConfig.h>
 #include <aws/kms/KMSClient.h>
 #include <aws/kms/model/ListKeysRequest.h>
 #include <aws/kms/model/SignRequest.h>
+
+// AWS KMS ML-DSA support — KeySpec::ML_DSA_{44,65,87} and
+// SigningAlgorithmSpec::ML_DSA_SHAKE_256 — arrived with the June 2025 KMS
+// model update. Gate the ML-DSA paths behind an SDK version check so older
+// SDKs build the module without ML-DSA (behaving exactly as before). The
+// threshold is set conservatively to a known-good release; it can be lowered
+// to the exact June-2025 patch to enable ML-DSA on more SDK versions.
+#if (AWS_SDK_VERSION_MAJOR > 1) || \
+    (AWS_SDK_VERSION_MAJOR == 1 && AWS_SDK_VERSION_MINOR > 11) || \
+    (AWS_SDK_VERSION_MAJOR == 1 && AWS_SDK_VERSION_MINOR == 11 && AWS_SDK_VERSION_PATCH >= 793)
+#define AWS_KMS_PKCS11_HAVE_ML_DSA 1
+#endif
 
 #include "pkcs11_compat.h"
 #include "openssl_compat.h"
@@ -41,6 +54,16 @@ typedef struct _session {
 
     CK_MECHANISM_TYPE sign_mechanism;
     CK_RSA_PKCS_PSS_PARAMS pss_params;
+
+    /* Streaming sign-API buffer (C_SignUpdate -> C_SignFinal).
+     * For ML-DSA, pkcs11-provider uses the multi-part Sign API: C_SignInit
+     * followed by one or more C_SignUpdate calls, then C_SignFinal. We
+     * accumulate the message here and submit it to KMS in one Sign request
+     * at C_SignFinal (matching AWS KMS's RAW MessageType semantics).
+     */
+    CK_BYTE_PTR sign_buffer;
+    CK_ULONG sign_buffer_len;
+    CK_ULONG sign_buffer_cap;
 } CkSession;
 
 static Aws::SDKOptions options;
@@ -377,6 +400,9 @@ CK_RV C_OpenSession(CK_SLOT_ID slotID, CK_FLAGS flags, CK_VOID_PTR pApplication,
     if (session == NULL) {
         return CKR_HOST_MEMORY;
     }
+    session->sign_buffer = NULL;
+    session->sign_buffer_len = 0;
+    session->sign_buffer_cap = 0;
     session->slot_id = slotID;
 
     *phSession = (CK_SESSION_HANDLE)session;
@@ -395,6 +421,7 @@ CK_RV C_CloseSession(CK_SESSION_HANDLE hSession) {
             it++;
         }
     }
+    if (session->sign_buffer != NULL) { free(session->sign_buffer); session->sign_buffer = NULL; }
     free(session);
     return CKR_OK;
 }
@@ -403,6 +430,7 @@ CK_RV C_CloseAllSessions(CK_SLOT_ID slotID) {
     for (auto it = active_sessions->begin(); it != active_sessions->end(); ) {
         CkSession *session = *it;
         if (session->slot_id == slotID) {
+            if (session->sign_buffer != NULL) { free(session->sign_buffer); session->sign_buffer = NULL; }
             free(session);
             active_sessions->erase(it);
         } else {
@@ -465,6 +493,26 @@ CK_RV C_GetMechanismInfo(CK_SLOT_ID slotID, CK_MECHANISM_TYPE type, CK_MECHANISM
             return CKR_MECHANISM_INVALID;
         }
         break;
+#ifdef AWS_KMS_PKCS11_HAVE_ML_DSA
+    case CKM_ML_DSA:
+        // For the PQ mechanisms, PKCS#11 v3.2 expresses ulMin/MaxKeySize as the
+        // public-key size in bytes (per FIPS 204 Table 2), matching the ML-KEM
+        // convention in the spec rather than a security-strength figure.
+        switch(slot.GetKeySpec()) {
+        case Aws::KMS::Model::KeySpec::ML_DSA_44:
+            keySize = 1312;
+            break;
+        case Aws::KMS::Model::KeySpec::ML_DSA_65:
+            keySize = 1952;
+            break;
+        case Aws::KMS::Model::KeySpec::ML_DSA_87:
+            keySize = 2592;
+            break;
+        default:
+            return CKR_MECHANISM_INVALID;
+        }
+        break;
+#endif
     default:
        return CKR_MECHANISM_INVALID;
     }
@@ -478,11 +526,23 @@ CK_RV C_GetMechanismList(CK_SLOT_ID slotID, CK_MECHANISM_TYPE_PTR pMechanismList
     if (pulCount == NULL_PTR) {
         return CKR_ARGUMENTS_BAD;
     }
+#ifdef AWS_KMS_PKCS11_HAVE_ML_DSA
+    const CK_ULONG mech_count = 3;
+#else
+    const CK_ULONG mech_count = 2;
+#endif
     if (pMechanismList != NULL) {
+        if (*pulCount < mech_count) {
+            *pulCount = mech_count;
+            return CKR_BUFFER_TOO_SMALL;
+        }
         pMechanismList[0] = CKM_RSA_PKCS;
         pMechanismList[1] = CKM_ECDSA;
+#ifdef AWS_KMS_PKCS11_HAVE_ML_DSA
+        pMechanismList[2] = CKM_ML_DSA;
+#endif
     }
-    *pulCount = 2;
+    *pulCount = mech_count;
     return CKR_OK;
 }
 
@@ -667,16 +727,89 @@ CK_RV C_SignInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OBJ
         memset(&session->pss_params, 0, sizeof(CK_RSA_PKCS_PSS_PARAMS));
     }
 
+    /* Reset any previously-accumulated streaming-sign buffer. */
+    if (session->sign_buffer != NULL) {
+        free(session->sign_buffer);
+        session->sign_buffer = NULL;
+    }
+    session->sign_buffer_len = 0;
+    session->sign_buffer_cap = 0;
+
     return CKR_OK;
 }
 
+/* Upper bound on bytes accumulated across C_SignUpdate calls. AWS KMS RAW
+ * signing tops out at 4096 bytes (the ML-DSA path), and the RSA/EC paths only
+ * ever sign a digest, so any larger stream can never yield a valid signature.
+ * Reject early instead of buffering unbounded data on the host. */
+#define SIGN_BUFFER_MAX 4096UL
+
 CK_RV C_SignUpdate(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pPart, CK_ULONG ulPartLen) {
+    CkSession *session = (CkSession*)hSession;
+    if (session == NULL) {
+        return CKR_SESSION_HANDLE_INVALID;
+    }
+    if (pPart == NULL_PTR && ulPartLen > 0) {
+        return CKR_ARGUMENTS_BAD;
+    }
+    if (ulPartLen == 0) {
+        return CKR_OK;
+    }
+    /* Bound total accumulation (also guards the size arithmetic below from
+     * overflow: once ulPartLen <= SIGN_BUFFER_MAX, the subtraction can't wrap). */
+    if (ulPartLen > SIGN_BUFFER_MAX ||
+        session->sign_buffer_len > SIGN_BUFFER_MAX - ulPartLen) {
+        debug("C_SignUpdate: accumulated message exceeds %lu-byte limit",
+              (unsigned long)SIGN_BUFFER_MAX);
+        return CKR_DATA_LEN_RANGE;
+    }
+    /* Grow the buffer if needed. Double-and-add growth to amortize allocations. */
+    CK_ULONG needed = session->sign_buffer_len + ulPartLen;
+    if (needed > session->sign_buffer_cap) {
+        CK_ULONG new_cap = session->sign_buffer_cap ? session->sign_buffer_cap : 4096;
+        while (new_cap < needed) new_cap *= 2;
+        CK_BYTE_PTR new_buf = (CK_BYTE_PTR)realloc(session->sign_buffer, new_cap);
+        if (new_buf == NULL) {
+            debug("C_SignUpdate: realloc to %lu bytes failed", (unsigned long)new_cap);
+            return CKR_HOST_MEMORY;
+        }
+        session->sign_buffer = new_buf;
+        session->sign_buffer_cap = new_cap;
+    }
+    memcpy(session->sign_buffer + session->sign_buffer_len, pPart, ulPartLen);
+    session->sign_buffer_len += ulPartLen;
     return CKR_OK;
 }
 
 CK_RV C_SignFinal(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pSignature, CK_ULONG_PTR pulSignatureLen) {
-    *pulSignatureLen = 0;
-    return CKR_OK;
+    CkSession *session = (CkSession*)hSession;
+    if (session == NULL) {
+        return CKR_SESSION_HANDLE_INVALID;
+    }
+    if (pulSignatureLen == NULL_PTR) {
+        return CKR_ARGUMENTS_BAD;
+    }
+    /* Delegate to C_Sign with the accumulated buffer. C_Sign handles both
+     * the size-query case (pSignature == NULL) and the actual-sign case.
+     * Free the accumulated buffer only when we've actually delivered the
+     * signature, so that the two-call pattern (query size, then sign) works:
+     * the first call returns the size, the second call returns the signature
+     * and frees the buffer. */
+    /* C_Sign rejects a NULL pData, so for the zero-length case (no C_SignUpdate
+     * calls) pass a valid non-const pointer to an empty buffer rather than
+     * casting away const from a string literal. */
+    static CK_BYTE empty_msg[1] = { 0 };
+    CK_RV rv = C_Sign(hSession,
+                      session->sign_buffer ? session->sign_buffer : empty_msg,
+                      session->sign_buffer_len,
+                      pSignature, pulSignatureLen);
+    if (pSignature != NULL_PTR && rv == CKR_OK) {
+        free(session->sign_buffer);
+        session->sign_buffer = NULL;
+        session->sign_buffer_len = 0;
+        session->sign_buffer_cap = 0;
+    }
+    return rv;
 }
 
 static const unsigned char rsa_id_sha256[] = { 0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20 };
@@ -719,21 +852,40 @@ CK_RV C_Sign(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_ULONG ulDataLen, 
     const RSA* rsa;
     const unsigned char* pubkey_bytes = key_data.GetUnderlyingData();
     EVP_PKEY* pkey = d2i_PUBKEY(NULL, &pubkey_bytes, key_data.GetLength());
+    if (pkey == NULL) {
+        debug("d2i_PUBKEY returned NULL — public key DER parse failed");
+        return CKR_FUNCTION_FAILED;
+    }
 
+    // Detect key type. For ML-DSA (OpenSSL 3.5+) EVP_PKEY_base_id returns a
+    // dynamically-assigned NID, so we use EVP_PKEY_is_a() with the canonical
+    // algorithm name to identify the variant. Cache the determination in
+    // key_type using EVP_PKEY_RSA / EVP_PKEY_EC / a sentinel for ML-DSA.
     int key_type = EVP_PKEY_base_id(pkey);
-    switch (key_type) {
-        case EVP_PKEY_RSA:
-            rsa = EVP_PKEY_get0_RSA(pkey);
-            sig_size = BN_num_bytes(RSA_get0_n(rsa));
-            break;
-        case EVP_PKEY_EC:
-            ec_key = EVP_PKEY_get0_EC_KEY(pkey);
-            sig_size = ECDSA_size(ec_key);
-            break;
-        default:
-            EVP_PKEY_free(pkey);
-            return CKR_FUNCTION_FAILED;
-
+#ifdef AWS_KMS_PKCS11_HAVE_ML_DSA
+    bool is_mldsa = false;
+#endif
+    if (key_type == EVP_PKEY_RSA) {
+        rsa = EVP_PKEY_get0_RSA(pkey);
+        sig_size = BN_num_bytes(RSA_get0_n(rsa));
+    } else if (key_type == EVP_PKEY_EC) {
+        ec_key = EVP_PKEY_get0_EC_KEY(pkey);
+        sig_size = ECDSA_size(ec_key);
+#if defined(AWS_KMS_PKCS11_HAVE_ML_DSA) && OPENSSL_VERSION_NUMBER >= 0x30000000L
+    } else if (EVP_PKEY_is_a(pkey, "ML-DSA-44")) {
+        is_mldsa = true;
+        sig_size = 2420;  // FIPS 204 Table 1
+    } else if (EVP_PKEY_is_a(pkey, "ML-DSA-65")) {
+        is_mldsa = true;
+        sig_size = 3309;
+    } else if (EVP_PKEY_is_a(pkey, "ML-DSA-87")) {
+        is_mldsa = true;
+        sig_size = 4627;
+#endif
+    } else {
+        debug("Unsupported key type in C_Sign: base_id=%d", key_type);
+        EVP_PKEY_free(pkey);
+        return CKR_FUNCTION_FAILED;
     }
     EVP_PKEY_free(pkey);
     pkey = NULL;
@@ -790,6 +942,27 @@ CK_RV C_Sign(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_ULONG ulDataLen, 
             req.SetMessage(Aws::Utils::CryptoBuffer(Aws::Utils::ByteBuffer(pData, ulDataLen)));
             req.SetMessageType(Aws::KMS::Model::MessageType::DIGEST);
             break;
+#ifdef AWS_KMS_PKCS11_HAVE_ML_DSA
+        case CKM_ML_DSA:
+            // ML-DSA signing via AWS KMS.
+            // AWS KMS Sign API accepts MessageType=RAW for messages up to 4096 bytes.
+            // For larger messages, EXTERNAL_MU pre-processing is required (FIPS 204 §6.2);
+            // not implemented here — callers should keep messages bounded.
+            if (!is_mldsa) {
+                debug("CKM_ML_DSA requested but key is not ML-DSA");
+                return CKR_KEY_TYPE_INCONSISTENT;
+            }
+            if (ulDataLen > 4096) {
+                debug("Message too large for CKM_ML_DSA RAW path: %lu bytes (max 4096); "
+                      "EXTERNAL_MU pre-processing not yet implemented",
+                      (unsigned long)ulDataLen);
+                return CKR_DATA_LEN_RANGE;
+            }
+            req.SetMessage(Aws::Utils::CryptoBuffer(Aws::Utils::ByteBuffer(pData, ulDataLen)));
+            req.SetMessageType(Aws::KMS::Model::MessageType::RAW);
+            req.SetSigningAlgorithm(Aws::KMS::Model::SigningAlgorithmSpec::ML_DSA_SHAKE_256);
+            break;
+#endif
         case CKM_RSA_PKCS:
             if (has_prefix(pData, ulDataLen, rsa_id_sha256, sizeof(rsa_id_sha256))) {
                 req.SetMessage(Aws::Utils::CryptoBuffer(Aws::Utils::ByteBuffer(pData + sizeof(rsa_id_sha256), ulDataLen - sizeof(rsa_id_sha256))));
@@ -832,6 +1005,8 @@ CK_RV C_Sign(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_ULONG ulDataLen, 
     }
     Aws::KMS::Model::SignResult response = res.GetResult();
 
+    // ML-DSA signatures are raw FIPS 204 bytes, not DER-wrapped, so they take the
+    // memcpy path below (key_type is neither EVP_PKEY_RSA nor EVP_PKEY_EC).
     if (key_type == EVP_PKEY_EC) {
         const unsigned char* sigbytes = response.GetSignature().GetUnderlyingData();
         ECDSA_SIG* sig = d2i_ECDSA_SIG(NULL, &sigbytes, response.GetSignature().GetLength());

--- a/aws_kms_pkcs11_test.c
+++ b/aws_kms_pkcs11_test.c
@@ -30,7 +30,72 @@ CK_RV get_and_dump_attribute(CK_FUNCTION_LIST* f, CK_SESSION_HANDLE session, CK_
 
     dump_bytes(name, (const unsigned char*)attrs[0].pValue, attrs[0].ulValueLen);
     free(attrs[0].pValue);
+    return CKR_OK;
+}
 
+// Exercises the multi-part signing path (C_SignInit -> C_SignUpdate* ->
+// C_SignFinal) with the same key and mechanism used by the single-shot test.
+// The message is fed in several chunks -- including a zero-length update -- to
+// cover the streaming buffer accumulation, and C_SignFinal is called with the
+// two-call (size query, then fetch) pattern. This is a shallow smoke test: it
+// only checks the calls succeed, don't segfault, and yield a non-empty
+// signature. It deliberately does NOT compare the length/bytes against the
+// single-shot signature, since some algorithms (e.g. ECDSA) produce signatures
+// whose DER length varies between invocations.
+CK_RV test_sign_multipart(CK_FUNCTION_LIST* f, CK_SESSION_HANDLE session, CK_OBJECT_HANDLE obj,
+                          CK_MECHANISM_PTR mechanism, const unsigned char* data, CK_ULONG data_len) {
+    
+    CK_RV res = f->C_SignInit(session, mechanism, obj);
+    if (res != CKR_OK) {
+        printf("Fail C_SignInit (multipart), res=%ld\n", res);
+        return res;
+    }
+    CK_ULONG first = data_len / 2;
+    res = f->C_SignUpdate(session, (CK_BYTE_PTR)data, first);
+    if (res != CKR_OK) {
+        printf("Fail C_SignUpdate (chunk 1), res=%ld\n", res);
+        return res;
+    }
+    
+    // Zero-length update should be a no-op and must not disturb the buffer.
+    res = f->C_SignUpdate(session, (CK_BYTE_PTR)data, 0);
+    if (res != CKR_OK) {
+        printf("Fail C_SignUpdate (zero-length), res=%ld\n", res);
+        return res;
+    }
+    res = f->C_SignUpdate(session, (CK_BYTE_PTR)(data + first), data_len - first);
+    if (res != CKR_OK) {
+        printf("Fail C_SignUpdate (chunk 2), res=%ld\n", res);
+        return res;
+    }
+    
+    // First call with a NULL buffer to learn the signature size...
+    CK_ULONG siglen = 0;
+    res = f->C_SignFinal(session, NULL_PTR, &siglen);
+    if (res != CKR_OK) {
+        printf("Failed to call C_SignFinal to get signature size, res=%ld\n", res);
+        return res;
+    }
+    if (siglen == 0) {
+        printf("C_SignFinal reported a zero-length signature\n");
+        return CKR_FUNCTION_FAILED;
+    }
+    
+    // ...then again to fetch the signature itself.
+    unsigned char* sig = (unsigned char*)malloc(siglen);
+    if (sig == NULL) {
+        printf("Failed to allocate memory for the multipart signature.\n");
+        return CKR_HOST_MEMORY;
+    }
+    res = f->C_SignFinal(session, sig, &siglen);
+    if (res != CKR_OK) {
+        printf("Fail C_SignFinal, res=%ld\n", res);
+        free(sig);
+        return res;
+    }
+    
+    dump_bytes("multipart_sig", sig, siglen);
+    free(sig);
     return CKR_OK;
 }
 
@@ -130,10 +195,17 @@ CK_RV test_all_keys_in_slot(CK_FUNCTION_LIST* f, CK_SLOT_ID slotID) {
         };
 
         CK_MECHANISM mechanism;
+        mechanism.pParameter = NULL_PTR;
+        mechanism.ulParameterLen = 0;
         if (key_type == CKK_RSA) {
             mechanism.mechanism = CKM_RSA_PKCS;
         } else if (key_type == CKK_ECDSA) {
             mechanism.mechanism = CKM_ECDSA;
+        } else if (key_type == CKK_ML_DSA) {
+            mechanism.mechanism = CKM_ML_DSA;
+        } else {
+            printf("Skipping object: unsupported key type %ld\n", (long)key_type);
+            continue;
         }
         res = f->C_SignInit(session, &mechanism, obj);
         if (res != CKR_OK) {
@@ -157,6 +229,13 @@ CK_RV test_all_keys_in_slot(CK_FUNCTION_LIST* f, CK_SLOT_ID slotID) {
         }
         dump_bytes("sig", sig, siglen);
         free(sig);
+        // Also exercise the multi-part (C_SignUpdate/C_SignFinal) path with the
+        // same key and mechanism.
+        res = test_sign_multipart(f, session, obj, &mechanism, DATA, sizeof(DATA));
+        if (res != CKR_OK) {
+            printf("Fail multipart sign test\n");
+            return res;
+        }
     }
     res = f->C_FindObjectsFinal(session);
     if (res != CKR_OK) {

--- a/pkcs11_compat.h
+++ b/pkcs11_compat.h
@@ -27,6 +27,39 @@
 #define CK_FALSE false
 #endif
 
+/*
+ * PKCS#11 v3.2 mechanism, key type, and parameter-set constants for ML-DSA
+ * (FIPS 204). Defined here only if the system pkcs11.h predates v3.2.
+ * Values match the OASIS PKCS#11 v3.2 spec (pkcs11t.h) and what
+ * Kryoptic / pkcs11-provider use:
+ *   CKM_ML_DSA = 0x1D, CKK_ML_DSA = 0x4A, CKA_PARAMETER_SET = 0x61D,
+ *   CKP_ML_DSA_{44,65,87} = 1/2/3.
+ */
+#ifndef CKM_ML_DSA
+#define CKM_ML_DSA 0x0000001DUL
+#endif
+#ifndef CKK_ML_DSA
+#define CKK_ML_DSA 0x0000004AUL
+#endif
+
+#ifndef CKA_PUBLIC_KEY_INFO
+#define CKA_PUBLIC_KEY_INFO 0x00000129UL
+#endif
+
+#ifndef CKA_COPYABLE
+#define CKA_COPYABLE 0x00000171UL
+#endif
+
+#ifndef CKA_PARAMETER_SET
+#define CKA_PARAMETER_SET 0x0000061DUL
+#endif
+
+#ifndef CKP_ML_DSA_44
+#define CKP_ML_DSA_44 0x00000001UL
+#define CKP_ML_DSA_65 0x00000002UL
+#define CKP_ML_DSA_87 0x00000003UL
+#endif
+
 /* opencryptoki in ubuntu 20.04 is missing that one */
 #ifndef CKR_ACTION_PROHIBITED
 #define CKR_ACTION_PROHIBITED			(0x1BUL)


### PR DESCRIPTION
## Summary
Adds ML-DSA-44/65/87 signing through AWS KMS as the PKCS#11 `CKM_ML_DSA`
mechanism, plus the multi-part Sign API pkcs11-provider uses to drive it.

## Dependency
Builds on #46 (SDK init-once lifecycle). That PR is what keeps the module from
crashing at process exit under pkcs11-provider; please review/merge it first,
and I'll rebase this on top if needed. The two diffs are disjoint — #46 touches
only C_Initialize/C_Finalize, this touches only the mechanism/sign paths.

## Scope
Signing-only — no key generation; keys are created out-of-band in KMS.

## Constants
Verified against the OASIS PKCS#11 v3.2 header: `CKM_ML_DSA=0x1D`,
`CKK_ML_DSA=0x4A`, `CKA_PARAMETER_SET=0x61D`, `CKP_ML_DSA_{44,65,87}=1/2/3`.

## Limitations
Messages > 4096 bytes are rejected (`CKR_DATA_LEN_RANGE`); KMS EXTERNAL_MU for
larger inputs isn't implemented. Fine for XML-DSig (canonicalized SignedInfo
stays well under 4 KB).

## Build requirements
aws-sdk-cpp >= 1.11.793, OpenSSL >= 3.5.